### PR TITLE
First steps towards dual-boot

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,89 +1,77 @@
-name: Generate gw_update.tar
+name: Build Bootloader
 
 on:
+  workflow_dispatch:
   push:
+    tags:
+      - "v*.*.*"
     branches:
       - main
-    tags:
-      - 'v*'
+  pull_request:
 
 jobs:
-  build-package:
-    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Checkout the repository with submodules
       - name: Checkout repository with submodules
         uses: actions/checkout@v3
         with:
           submodules: true  # Clone submodules with --recurse-submodules
 
-      # 2. Install necessary dependencies (binutils, wget, etc.)
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y binutils-arm-none-eabi wget
 
-      # 3. Install the ARM compiler
       - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
         uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:
           release: '13.3.Rel1'
 
-      # 4. Generate the bootloader binary
       - name: Generate gnw_bootloader.bin
         run: |
-          make -j$(nproc)
+          make clean
+          DEBUG=0 make -j$(nproc)
+          mv build/gnw_bootloader.bin gnw_bootloader.bin
 
-  release-package:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      - name: Upload gnw_bootloader.bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: gnw_bootloader.bin
+          path: "gnw_bootloader.bin"
+
+      - name: Generate gnw_bootloader_0x08032000.bin
+        run: |
+          make clean
+          DEBUG=0 INTFLASH_ADDRESS=0x08032000 make -j$(nproc)
+          mv build/gnw_bootloader.bin gnw_bootloader_0x08032000.bin
+
+      - name: Upload gnw_bootloader_0x08032000.bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: gnw_bootloader_0x08032000.bin
+          path: "gnw_bootloader_0x08032000.bin"
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    needs:
+      - build
 
     steps:
-      # 1. Checkout the repository with submodules
-      - name: Checkout repository with submodules
-        uses: actions/checkout@v3
+      - name: Download All Binaries
+        uses: actions/download-artifact@v4
         with:
-          submodules: true  # Clone submodules with --recurse-submodules
+          path: release
+          pattern: gnw_bootloader*.bin
+          merge-multiple: true
 
-      # 2. Install necessary dependencies (binutils, wget, etc.)
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y binutils-arm-none-eabi python3 python3-pip libhidapi-hidraw0 libftdi1 libftdi1-2 make git wget
+      - name: Display all downloaded binaries
+        run: ls -alh release/
 
-      # 3. Install the ARM compiler
-      - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          release: '13.3.Rel1'
-
-      # 4. Generate the update files
-      - name: Generate firmware_update.bin and gw_update.tar
-        run: |
-          make -j$(nproc)
-
-      # 5. Create a release and upload files
-      - name: Create Release
-        uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          body_path: CHANGELOG.md
-          draft: false
-          prerelease: false
-
-      # 6. Add bootloader file as assets
-      - name: Upload gnw_bootloader.bin to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/gnw_bootloader.bin
-          asset_name: gnw_bootloader.bin
-          asset_content_type: application/octet-stream
+          files: |
+            release/*

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 TARGET = gnw_bootloader
 
-DEBUG = 0
-
-OPT = -O2 -ggdb3
-
 # To enable verbose, append VERBOSE=1 to make, e.g.:
 # make VERBOSE=1
 ifneq ($(strip $(VERBOSE)),1)

--- a/Makefile.common
+++ b/Makefile.common
@@ -5,8 +5,12 @@ SHELL := /bin/bash
 ######################################
 # debug build?
 DEBUG ?= 1
-# optimization
-OPT ?= -Og
+
+ifeq ($(DEBUG), 1)
+OPT ?= -Og -ggdb3
+else
+OPT ?= -Os -flto
+endif
 
 SINGLE_FONT ?= 0
 


### PR DESCRIPTION
To get dual boot working, both the patched-firmware as well as this bootloader have to fit into bank1. The first step was to get the bootloader binary smaller. The following was enough to reduce the size from ~59KB to ~38KB:

1. Set the optimize-for-size `-Os` flag.
2. Enable link-time-optimizations `-flto`.

The next part is change the base address, which was super easy since you already had all the code there ;). I updated the CI to:

1. Upload binaries as workflow artifacts for easy inspection.
2. We now build an additional binary that has a base address at `0x08032000`. This is 200KB into bank1. This leaves a tiny bit of extra room incase this bootloader grows, and it leaves just enough room to have a "fully internal" mario firmware if smb2 is removed.
3. I also updated the CI to publish this to tagged releases. The "official" github actions for doing this are super old/deprecated, so I swapped them out for alternatives that I use in other projects. The CI now runs on all commits/PRs to ensure nothing breaks. Tagged releases can be done through the github interface, and changelogs can be auto-generated (doesn't use `CHANGELOG.md`).

You can see an example of the CI working here:
https://github.com/BrianPugh/game-and-watch-bootloader/releases/tag/v99.99.99
https://github.com/BrianPugh/game-and-watch-bootloader/actions/runs/13404052850

## Related work
The [gnw-patch](https://github.com/BrianPugh/gnwmanager/tree/gnw-patch) branch of gnwmanager has been updated to offer a simplified patching solution for mario/zelda firmwares. I was able to keep a decent amount of customizations, but removed some for simplicity. It also has the custom firmware components pre-compiled so that the user doesn't need to compile anything. I also cached all possible keystone-engine queries, so that it doesn't need to be installed (common issue on raspberry pis). This branch is still very much a WIP, so treat it as such.

## Next Steps
* After this is integrated, I can have `gnwmanager` automatically download the latest `gnw_bootloader_0x08032000.bin` for dual-booting.
* We need to discuss the communication the CFW needs to perform to the bootloader/retro-go to properly handle external flash.
* lots of testing ;) 
