### PR TITLE
Set HDMI_CEC to 0, signaling 0 external flash offset.

### DIFF
--- a/startup_stm32h7b0xx.s
+++ b/startup_stm32h7b0xx.s
@@ -237,7 +237,7 @@ g_pfnVectors:
   .word     SAI2_IRQHandler                   /* SAI2                         */
   .word     OCTOSPI1_IRQHandler               /* OCTOSPI1                     */
   .word     LPTIM1_IRQHandler                 /* LPTIM1                       */
-  .word     CEC_IRQHandler                    /* HDMI_CEC                     */
+  .word     0                                 /* HDMI_CEC                     */
   .word     I2C4_EV_IRQHandler                /* I2C4 Event                   */
   .word     I2C4_ER_IRQHandler                /* I2C4 Error                   */
   .word     SPDIF_RX_IRQHandler               /* SPDIF_RX                     */


### PR DESCRIPTION
When dual-booting, this doesn't do anything, but when this bootloader is at the base bank1 address, this will tell retro-go-sd that the bootloader doesn't take up any external flash. retro-go-sd has a safety check that will assume 0 external flash is used when the HDMI_CEC value is stock-like (pointing to an address), so technically this PR is unnecessary. However, there's no harm in following our convention.