### PR TITLE
Fix release title/changelog

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -73,5 +73,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          name: Release ${{ github.ref_name }}
+          body_path: CHANGELOG.md
           files: |
             release/*

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true  # Clone submodules with --recurse-submodules
 
@@ -60,6 +60,12 @@ jobs:
       - build
 
     steps:
+      # Reclone repository to get CHANGELOG.md
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
       - name: Download All Binaries
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Addresses https://github.com/sylverb/game-and-watch-bootloader/pull/2#issuecomment-2670675851

@sylverb this should be very similar to how it was functioning before. I'd recommend making similar updates to the other repos (using `softprops/action-gh-release@v2`)

Example tag:

https://github.com/BrianPugh/game-and-watch-bootloader/releases/tag/v100.100.100